### PR TITLE
change .captures-container width to fix broken scoreboard markup when player has more than 9 captures

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -2427,7 +2427,7 @@ input:focus {
 #scoredetailed .item .captures .captures-container {
     display: inline-block;
     position: relative;
-    width: 50px;
+    width: 50%;
 }
 
 #scoredetailed .item .captures .captures-container .captures-icon {


### PR DESCRIPTION
fix broken scoreboard markup when player has more than 9 captures.
fix #29 

![image](https://user-images.githubusercontent.com/12018713/79027733-fe98ed00-7b95-11ea-9a73-9f87e7c45b79.png)
