### PR TITLE
Allow enabling development mode with ?dev query string

### DIFF
--- a/src/js/Game.js
+++ b/src/js/Game.js
@@ -1,4 +1,7 @@
-window.DEVELOPMENT = /^http:\/\/127\.0\.0\.1:[0-9]{1,5}\/?$/.test(window.origin);
+window.DEVELOPMENT = (
+    /^http:\/\/127\.0\.0\.1:[0-9]{1,5}\/?$/.test(window.origin) ||
+    (new URLSearchParams(window.location.search)).has('dev')
+);
 
 window.game = {
     protocol: 5,


### PR DESCRIPTION
Replacement for #45 since that PR was goofed up

Incorporates URLSearchParam suggestion

`|| ''` was unnecessary, seems `.search` is always at least the empty string