### PR TITLE
Update Constants.js

### DIFF
--- a/src/js/Constants.js
+++ b/src/js/Constants.js
@@ -115,7 +115,7 @@ window.CountryNames = {
   SE: 'Sweden',
   CH: 'Switzerland',
   SY: 'Syrian Arab Republic',
-  TW: 'Taiwan',
+  TW: 'Republic of China',
   TZ: 'Tanzania',
   TH: 'Thailand',
   TT: 'Trinidad and Tobago',


### PR DESCRIPTION
Taiwan is a country, but Taiwan is just the name of an island. The Republic of China is the name of the country, and it is not equal to the People's Republic of China. 
Many people confuse the Republic of China (ROC) with the People's Republic of China (PRC), but they are two separate governments. The ROC has existed since 1912 and currently governs Taiwan. It has its own military, passport, flag, and elected president. It's important not to confuse the ROC with the PRC, which was established in 1949.